### PR TITLE
login.shにパラメータ指定機能を追加（CycleEnv対応）

### DIFF
--- a/login.sh
+++ b/login.sh
@@ -1,6 +1,61 @@
 #!/usr/bin/env bash
-EB_ENV=$(./01_get_eb_envs.sh | fzf)
-echo "EB env: ${EB_ENV}"
+
+ENVIRONMENTS=(
+    "photoruction-php82-alpha"
+    "photoruction-php82-beta"
+    "photoruction-php82-gamma"
+)
+
+show_usage() {
+    echo "Usage: $0 [eb_env_or_cycle]"
+    echo "  eb_env_or_cycle: EB environment name or CycleEnv tag value (e.g. red, green, blue)"
+    echo ""
+    echo "If not provided, you'll be prompted to select from available options."
+}
+
+EB_ENV_PARAM="$1"
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+    show_usage
+    exit 0
+fi
+
+if [ -n "$EB_ENV_PARAM" ]; then
+    # CycleEnv タグで環境を検索
+    RESOLVED_ENV=""
+    for env in "${ENVIRONMENTS[@]}"; do
+        ENV_ARN=$(aws elasticbeanstalk describe-environments \
+            --environment-names "$env" \
+            --query 'Environments[0].EnvironmentArn' \
+            --output text 2>/dev/null)
+
+        if [ -z "$ENV_ARN" ] || [ "$ENV_ARN" = "None" ]; then
+            continue
+        fi
+
+        CYCLE_ENV_TAG=$(aws elasticbeanstalk list-tags-for-resource \
+            --resource-arn "$ENV_ARN" \
+            --query 'ResourceTags[?Key==`CycleEnv`].Value' \
+            --output text 2>/dev/null)
+
+        if [[ "${CYCLE_ENV_TAG,,}" == "${EB_ENV_PARAM,,}" ]]; then
+            RESOLVED_ENV="$env"
+            break
+        fi
+    done
+
+    if [ -n "$RESOLVED_ENV" ]; then
+        EB_ENV="$RESOLVED_ENV"
+        echo "CycleEnv '${EB_ENV_PARAM}' -> EB env: ${EB_ENV}"
+    else
+        EB_ENV="$EB_ENV_PARAM"
+        echo "Using specified EB env: ${EB_ENV}"
+    fi
+else
+    EB_ENV=$(./01_get_eb_envs.sh | fzf)
+    echo "EB env: ${EB_ENV}"
+fi
+
 EB_INSTANCE=$(./02_get_instances.sh ${EB_ENV} | fzf)
 echo "EB instance: ${EB_INSTANCE}"
 ./03_connect_to_instance.sh ${EB_INSTANCE}

--- a/login.sh
+++ b/login.sh
@@ -8,9 +8,9 @@ ENVIRONMENTS=(
 
 show_usage() {
     echo "Usage: $0 [eb_env_or_cycle]"
-    echo "  eb_env_or_cycle: EB environment name or CycleEnv tag value (e.g. red, green, blue)"
+    echo "  eb_env_or_cycle: EB環境名 または CycleEnvタグの値（例: red, green, blue）"
     echo ""
-    echo "If not provided, you'll be prompted to select from available options."
+    echo "省略した場合は、一覧から選択するプロンプトが表示されます。"
 }
 
 EB_ENV_PARAM="$1"

--- a/login.sh
+++ b/login.sh
@@ -9,8 +9,7 @@ ENVIRONMENTS=(
 show_usage() {
     echo "Usage: $0 [eb_env_or_cycle]"
     echo "  eb_env_or_cycle: EB環境名 または CycleEnvタグの値（例: red, green, blue）"
-    echo ""
-    echo "省略した場合は、一覧から選択するプロンプトが表示されます。"
+    echo "                   省略した場合は、一覧から選択するプロンプトが表示されます。"
 }
 
 EB_ENV_PARAM="$1"


### PR DESCRIPTION
## Summary

- EB環境名を引数で渡せるようにした（省略時は従来通りfzfで対話選択）
- CycleEnvタグ値（`red` / `green` / `blue`）を引数で渡すと対応するEB環境を自動解決
- `-h` / `--help` オプションを追加

## 使い方

```bash
# 従来通り（fzfで選択）
./login.sh

# EB環境名を直接指定
./login.sh photoruction-php82-alpha

# CycleEnvタグ値で指定（大文字小文字不問）
./login.sh red
./login.sh green
./login.sh blue
```

## Test plan

- [x] `./login.sh -h` でヘルプが表示される
- [x] `./login.sh` で従来通りfzf選択できる
- [x] `./login.sh red` でCycleEnv=RedのEB環境に接続できる
- [x] `./login.sh photoruction-php82-alpha` で直接指定した環境に接続できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)